### PR TITLE
[Bug fix] Add file type recognition in windows for non MS browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,18 @@ ember install csv-anchor
 Usage
 ------------------------------------------------------------------------------
 
-See the dummy app for usage details.
+You can override the downloaded file name by specifying the `fileName` argument:
+
+```handlebars
+{{component "ember-csv@file-anchor"
+  data=data
+  fileName="foobar"
+}}
+```
+
+...with this argument, the download will show up as `foobar.csv` on your computer.
+
+You can always play with the dummy app for usage details (See contributing).
 
 Contributing
 ------------------------------------------------------------------------------

--- a/addon/components/file-anchor.js
+++ b/addon/components/file-anchor.js
@@ -6,7 +6,9 @@ import { isArray } from '@ember/array';
 export default Component.extend({
   tagName: 'a',
 
-  attributeBindings: ['href'],
+  attributeBindings: ['href', 'download'],
+
+  fileName: 'download',
 
   didReceiveAttrs() {
     this._super(...arguments);
@@ -20,17 +22,18 @@ export default Component.extend({
     this._super(...arguments);
 
     if (window) {
+      const downloadName = this.set('download', `${this.get('fileName')}.csv`);
       const reducedString = this.get('data').reduce(
         (csvString, csvRow) => `${csvString}${csvRow.join()}\n`, ''
       ).trim();
 
       if (get(window, 'navigator.msSaveOrOpenBlob')) {
-        // Use msSaveOrOpenBlob if it exists because some MSFT browsers
+        // Use msSaveOrOpenBlob if it exists because MSFT browsers
         // don't support Data URI's in the anchor href
         this.set('click', () => {
           const blob = new Blob([reducedString], { type: 'text/csv', endings: 'native' });
 
-          window.navigator.msSaveOrOpenBlob(blob, 'download.csv');
+          window.navigator.msSaveOrOpenBlob(blob, downloadName);
         });
       } else {
         // Else, attach the Data URI for all other modern browsers


### PR DESCRIPTION
In Windows (using Chrome, not Edge), I noticed that there was no file type specified for the download file, so Windows was confused about how to open the download. I couldn't reproduce this in OSX using Chrome, only Windows. It's simple enough to fix - adding a download attribute to the anchor (specifying .csv extension) makes this work.

Testing done 
- Added integration tests to assert for new attributes 
- Added tests for overriding fileName argument

Browser tests (Chrome)
_13 assertions of 13 passed, 0 failed._

Scenario test suite
_All 7 scenarios succeeded_