### PR TITLE
use correct package name for install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Installation
 ------------------------------------------------------------------------------
 
 ```
-ember install csv-anchor
+ember install ember-csv
 ```
 
 Usage


### PR DESCRIPTION
The readme currently says `ember install csv-anchor` but that fails because it isn't the name of the package.